### PR TITLE
fix: fixes broken f010820fc498_add_unique_quotas_project_resource migration

### DIFF
--- a/neutron/Chart.yaml
+++ b/neutron/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 appVersion: v1.0.0
 description: OpenStack-Helm Neutron
 name: neutron
-version: 0.3.1
+version: 0.3.1-beskar-cloud-1
 home: https://docs.openstack.org/neutron/latest/
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_vertical.png
 sources:

--- a/neutron/templates/bin/_db-sync.sh.tpl
+++ b/neutron/templates/bin/_db-sync.sh.tpl
@@ -16,6 +16,14 @@ limitations under the License.
 
 set -ex
 
+# fix f010820fc498_add_unique_quotas_project_resource migration
+migration_file=$(find /var/lib/ -name "f010820fc498_add_unique_quotas_project_resource.py" || true)
+
+if [ -s "${migration_file}" ]; then
+  cp -vf "${migration_file}" "${migration_file}.backup"
+  sed 's|quotas.c.project_id|quotas.c.tenant_id|g' "${migration_file}.backup" > "${migration_file}"
+fi
+
 neutron-db-manage \
   --config-file /etc/neutron/neutron.conf \
 {{- if ( has "tungstenfabric" .Values.network.backend ) }}


### PR DESCRIPTION
corrects mismatch project / tenant naming in neutron DB