### PR TITLE
feat: Add documented neutron dvr support with multiple l3 agents in dvr

### DIFF
--- a/neutron/Chart.yaml
+++ b/neutron/Chart.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 appVersion: v1.0.0
 description: OpenStack-Helm Neutron
 name: neutron
-version: 0.3.1
+version: 0.3.1-beskar-cloud-2
 home: https://docs.openstack.org/neutron/latest/
 icon: https://www.openstack.org/themes/openstack/images/project-mascots/Neutron/OpenStack_Project_Neutron_vertical.png
 sources:

--- a/neutron/templates/configmap-etc.yaml
+++ b/neutron/templates/configmap-etc.yaml
@@ -260,8 +260,8 @@ data:
   policy.yaml: {{ toYaml $envAll.Values.conf.policy | b64enc }}
   neutron.conf: {{ include "helm-toolkit.utils.to_oslo_conf" $envAll.Values.conf.neutron | b64enc }}
   logging.conf: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.logging | b64enc }}
-  fwaas_driver.ini: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.fwaas_driver | b64enc }}
-  neutron_vpnaas.conf: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.neutron_vpnaas | b64enc }}
+  fwaas_driver.ini: {{ default "\"\"" (include "helm-toolkit.utils.to_oslo_conf" .Values.conf.fwaas_driver | b64enc) }}
+  neutron_vpnaas.conf: {{ default "\"\"" (include "helm-toolkit.utils.to_oslo_conf" .Values.conf.neutron_vpnaas | b64enc) }}
   api_audit_map.conf: {{ include "helm-toolkit.utils.to_oslo_conf" .Values.conf.api_audit_map | b64enc }}
   dhcp_agent.ini: {{ include "helm-toolkit.utils.to_oslo_conf" $envAll.Values.conf.dhcp_agent | b64enc }}
   l3_agent.ini: {{ include "helm-toolkit.utils.to_oslo_conf" $envAll.Values.conf.l3_agent | b64enc }}

--- a/neutron/templates/daemonset-l3-agent.yaml
+++ b/neutron/templates/daemonset-l3-agent.yaml
@@ -54,24 +54,27 @@ exec:
 {{- $mounts_neutron_l3_agent := .Values.pod.mounts.neutron_l3_agent.neutron_l3_agent }}
 {{- $mounts_neutron_l3_agent_init := .Values.pod.mounts.neutron_l3_agent.init_container }}
 
+# L3 agent manifest name used to override all related manifests names (l3-agent vs l3-agent-snat)
+{{- $l3_agent_manifest_name := .Values.conf.l3_agent.manifest_name }}
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: neutron-l3-agent
+  name: {{ printf "neutron-%s" $l3_agent_manifest_name }}
   annotations:
     {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" }}
   labels:
-{{ tuple $envAll "neutron" "l3-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+{{ tuple $envAll "neutron" $l3_agent_manifest_name | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
 spec:
   selector:
     matchLabels:
-{{ tuple $envAll "neutron" "l3-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+{{ tuple $envAll "neutron" $l3_agent_manifest_name | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
 {{ tuple $envAll "l3_agent" | include "helm-toolkit.snippets.kubernetes_upgrades_daemonset" | indent 2 }}
   template:
     metadata:
       labels:
-{{ tuple $envAll "neutron" "l3-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+{{ tuple $envAll "neutron" $l3_agent_manifest_name | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
       annotations:
 {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" | indent 8 }}
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
@@ -283,9 +286,9 @@ spec:
 
 {{- if .Values.manifests.daemonset_l3_agent }}
 {{- $envAll := . }}
-{{- $daemonset := "l3-agent" }}
+{{- $daemonset := $envAll.Values.conf.l3_agent.manifest_name }}
 {{- $configMapName := "neutron-etc" }}
-{{- $serviceAccountName := "neutron-l3-agent" }}
+{{- $serviceAccountName := printf "neutron-%s" $envAll.Values.conf.l3_agent.manifest_name }}
 {{- $dependencyOpts := dict "envAll" $envAll "dependencyMixinParam" $envAll.Values.network.backend "dependencyKey" "l3" -}}
 {{- $_ := include "helm-toolkit.utils.dependency_resolver" $dependencyOpts | toString | fromYaml }}
 {{ tuple $envAll "pod_dependency" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}

--- a/neutron/values.yaml
+++ b/neutron/values.yaml
@@ -1891,6 +1891,7 @@ conf:
       #dhcp-option-force=26,1450
 
   l3_agent:
+    manifest_name: "l3-agent"
     DEFAULT:
       # (NOTE)portdirect: if unset this is populated dyanmicly from the value in
       # 'network.backend' to sane defaults.


### PR DESCRIPTION
OpenStack neutron OVS backend support for proper DVR mode according docs[1].


[1] https://docs.openstack.org/neutron/yoga/admin/deploy-ovs-ha-dvr.html